### PR TITLE
feat: support from/to time range query in cycle signers endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@stacks/transactions": "^6.1.0",
         "@types/node": "^20.16.1",
         "bignumber.js": "^9.1.2",
+        "date-fns": "^4.1.0",
         "env-schema": "^5.1.0",
         "evt": "^1.11.2",
         "fastify": "4.15.0",
@@ -4152,6 +4153,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@stacks/transactions": "^6.1.0",
     "@types/node": "^20.16.1",
     "bignumber.js": "^9.1.2",
+    "date-fns": "^4.1.0",
     "env-schema": "^5.1.0",
     "evt": "^1.11.2",
     "fastify": "4.15.0",

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -1,0 +1,8 @@
+export class InvalidRequestError extends Error {
+  status: number;
+  constructor(msg: string, status: number = 400) {
+    super(msg);
+    this.name = this.constructor.name;
+    this.status = status;
+  }
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -50,7 +50,7 @@ export function parseTime(timeStr: string): Date | null {
   }
 
   if (timeStr.startsWith('now-')) {
-    const relativeMatch = timeStr.match(/now-(\d+)(s|m|h|d|w|mo|y)/i);
+    const relativeMatch = timeStr.match(/now-(\d+)(s|mo|m|h|d|w|y)/i);
     if (relativeMatch) {
       const [, amount, unit] = relativeMatch;
       const unitsMap: Record<string, keyof Duration> = {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,5 @@
 import { addAbortListener } from 'node:events';
+import { parseISO, sub, isValid, Duration } from 'date-fns';
 
 export const isDevEnv = process.env.NODE_ENV === 'development';
 export const isTestEnv = process.env.NODE_ENV === 'test';
@@ -36,4 +37,42 @@ export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
       reject(signal?.reason);
     }
   });
+}
+
+/**
+ * Helper function to parse relative or ISO time strings
+ * @param timeStr - Examples: 'now', 'now-1d', 'now-3h', '2024-11-01T15:16:53.891Z'
+ * @returns Date object or null if parsing failed
+ */
+export function parseTime(timeStr: string): Date | null {
+  if (timeStr === 'now') {
+    return new Date();
+  }
+
+  if (timeStr.startsWith('now-')) {
+    const relativeMatch = timeStr.match(/now-(\d+)(s|m|h|d|w|mo|y)/i);
+    if (relativeMatch) {
+      const [, amount, unit] = relativeMatch;
+      const unitsMap: Record<string, keyof Duration> = {
+        s: 'seconds',
+        m: 'minutes',
+        h: 'hours',
+        d: 'days',
+        w: 'weeks',
+        mo: 'months',
+        y: 'years',
+      };
+      if (unitsMap[unit]) {
+        return sub(new Date(), { [unitsMap[unit]]: parseInt(amount) });
+      }
+    }
+  } else {
+    const date = parseISO(timeStr);
+    if (isValid(date)) {
+      return date;
+    }
+  }
+
+  // Return null if parsing failed
+  return null;
 }


### PR DESCRIPTION
Closes https://github.com/hirosystems/signer-metrics-api/issues/32

Add support for specifying a time range for the `/v1/cycles/{n}/signers` endpoint via query parameters.

Usage: `?from={timestamp}&to=${timestamp}`

Where `timestamp` can be specified using relative time ranges and/or ISO timestamps, e.g.
* `?from=now-2h&to=now` (relative time ranges)
* `?from=2024-11-01T15:16:53.891Z&to=2024-11-02T15:16:53.891Z` (human readable ISO timestamp)