### PR TITLE
feat: add slot_index property to signers

### DIFF
--- a/migrations/1731067485167_reward_set_signers-slot-index.ts
+++ b/migrations/1731067485167_reward_set_signers-slot-index.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  // rename reward_set_signers rather than delete in case of rollback
+  pgm.dropIndex('reward_set_signers', ['signer_key']);
+  pgm.dropIndex('reward_set_signers', ['block_height']);
+  pgm.dropIndex('reward_set_signers', ['cycle_number']);
+  pgm.dropConstraint('reward_set_signers', 'reward_set_signers_cycle_unique');
+  pgm.renameTable('reward_set_signers', 'reward_set_signers_old-no-slot-index');
+
+  pgm.createTable('reward_set_signers', {
+    id: {
+      type: 'serial',
+      primaryKey: true,
+    },
+    // AKA reward_cycle
+    cycle_number: {
+      type: 'integer',
+      notNull: true,
+    },
+    signer_key: {
+      type: 'bytea',
+      notNull: true,
+    },
+    signer_weight: {
+      type: 'integer',
+      notNull: true,
+    },
+    signer_stacked_amount: {
+      type: 'numeric',
+      notNull: true,
+    },
+    slot_index: {
+      type: 'integer',
+      notNull: true,
+    },
+  });
+
+  pgm.createIndex('reward_set_signers', ['signer_key']);
+  pgm.createIndex('reward_set_signers', ['cycle_number']);
+
+  pgm.createConstraint('reward_set_signers', 'reward_set_signers_cycle_unique', {
+    unique: ['signer_key', 'cycle_number'],
+  });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable('reward_set_signers');
+  pgm.renameTable('reward_set_signers_old-no-slot-index', 'reward_set_signers');
+}

--- a/src/api/routes/cycle.ts
+++ b/src/api/routes/cycle.ts
@@ -75,6 +75,7 @@ export const CycleRoutes: FastifyPluginCallback<
         const formatted = results.map(result => {
           const cycleSinger: CycleSigner = {
             signer_key: result.signer_key,
+            slot_index: result.slot_index,
             weight: result.weight,
             weight_percentage: result.weight_percentage,
             stacked_amount: result.stacked_amount,
@@ -135,6 +136,7 @@ export const CycleRoutes: FastifyPluginCallback<
         }
         const cycleSigner: CycleSignerResponse = {
           signer_key: signer.signer_key,
+          slot_index: signer.slot_index,
           weight: signer.weight,
           weight_percentage: signer.weight_percentage,
           stacked_amount: signer.stacked_amount,

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -129,6 +129,7 @@ export type BlocksResponse = Static<typeof BlocksResponseSchema>;
 
 export const CycleSignerSchema = Type.Object({
   signer_key: Type.String(),
+  slot_index: Type.Integer({ description: 'Index of the signer in the stacker set' }),
   weight: Type.Integer({
     description:
       'Voting weight of this signer (based on slots allocated which is proportional to stacked amount)',

--- a/src/pg/chainhook/chainhook-pg-store.ts
+++ b/src/pg/chainhook/chainhook-pg-store.ts
@@ -441,14 +441,13 @@ export class ChainhookPgStore extends BasePgStoreModule {
       throw new Error(`Missing cycle_number for block ${block.block_identifier.index} reward set`);
     }
 
-    const dbRewardSetSigners = block.metadata.reward_set?.signers?.map(signer => {
+    const dbRewardSetSigners = block.metadata.reward_set?.signers?.map((signer, index) => {
       const dbSigner: DbRewardSetSigner = {
         cycle_number: block.metadata.cycle_number as number,
-        burn_block_height: dbBlock.burn_block_height,
-        block_height: dbBlock.block_height,
         signer_key: normalizeHexString(signer.signing_key),
         signer_weight: signer.weight,
         signer_stacked_amount: signer.stacked_amt,
+        slot_index: index,
       };
       return dbSigner;
     });

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -430,6 +430,7 @@ export class PgStore extends BasePgStore {
     const dbRewardSetSigners = await sql<
       {
         signer_key: string;
+        slot_index: number;
         weight: number;
         weight_percentage: number;
         stacked_amount: string;
@@ -447,6 +448,7 @@ export class PgStore extends BasePgStore {
         -- Fetch the signers for the given cycle
         SELECT
           rss.signer_key,
+          rss.slot_index,
           rss.signer_weight,
           rss.signer_stacked_amount
         FROM reward_set_signers rss
@@ -521,6 +523,7 @@ export class PgStore extends BasePgStore {
       )
       SELECT
         sd.signer_key,
+        sd.slot_index,
         sd.signer_weight AS weight,
         sd.signer_stacked_amount AS stacked_amount,
         ROUND(sd.signer_weight * 100.0 / (SELECT SUM(signer_weight) FROM reward_set_signers WHERE cycle_number = ${cycleNumber}), 3)::float8 AS weight_percentage,
@@ -548,6 +551,7 @@ export class PgStore extends BasePgStore {
     const dbRewardSetSigner = await this.sql<
       {
         signer_key: string;
+        slot_index: number;
         weight: number;
         weight_percentage: number;
         stacked_amount: string;
@@ -565,6 +569,7 @@ export class PgStore extends BasePgStore {
         -- Fetch the specific signer for the given cycle
         SELECT
           rss.signer_key,
+          rss.slot_index,
           rss.signer_weight,
           rss.signer_stacked_amount
         FROM reward_set_signers rss
@@ -639,6 +644,7 @@ export class PgStore extends BasePgStore {
       )
       SELECT
         sd.signer_key,
+        sd.slot_index,
         sd.signer_weight AS weight,
         sd.signer_stacked_amount AS stacked_amount,
         ROUND(sd.signer_weight * 100.0 / (SELECT SUM(signer_weight) FROM reward_set_signers WHERE cycle_number = ${cycleNumber}), 3)::float8 AS weight_percentage,

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -19,11 +19,10 @@ export type DbBlockSignerSignature = {
 
 export type DbRewardSetSigner = {
   cycle_number: number;
-  burn_block_height: number;
-  block_height: number;
   signer_key: PgBytea;
   signer_weight: number;
   signer_stacked_amount: PgNumeric;
+  slot_index: number;
 };
 
 export type DbBlockResponse = {

--- a/src/stacks-core-rpc/stacker-set-updater.ts
+++ b/src/stacks-core-rpc/stacker-set-updater.ts
@@ -93,14 +93,13 @@ export function rpcStackerSetToDbRewardSetSigners(
   rpcResponse: RpcStackerSetResponse,
   cycleNumber: number
 ): DbRewardSetSigner[] {
-  return rpcResponse.stacker_set.signers.map(entry => {
+  return rpcResponse.stacker_set.signers.map((entry, index) => {
     const rewardSetSigner: DbRewardSetSigner = {
       cycle_number: cycleNumber,
-      block_height: 0,
-      burn_block_height: 0,
       signer_key: Buffer.from(entry.signing_key.replace(/^0x/, ''), 'hex'),
       signer_weight: entry.weight,
       signer_stacked_amount: entry.stacked_amt.toString(),
+      slot_index: index,
     };
     return rewardSetSigner;
   });

--- a/tests/db/endpoints.test.ts
+++ b/tests/db/endpoints.test.ts
@@ -199,6 +199,7 @@ describe('Endpoint tests', () => {
     const testSigner = body.results.find(r => r.signer_key === testSignerKey);
     const expectedSignerData: CycleSigner = {
       signer_key: '0x02e8620935d58ebffa23c260f6917cbd0915ea17d7a46df17e131540237d335504',
+      slot_index: 3,
       weight: 38,
       weight_percentage: 76,
       stacked_amount: '250000000000000',
@@ -219,6 +220,7 @@ describe('Endpoint tests', () => {
     const miaSigner = body.results.find(r => r.signer_key === miaSignerKey);
     const expectedMiaSignerData: CycleSigner = {
       signer_key: '0x0399649284ed10a00405f032f8567b5e5463838aaa00af8d6bc9da71dda4e19c9c',
+      slot_index: 9,
       weight: 1,
       weight_percentage: 2,
       stacked_amount: '7700000000000',
@@ -259,6 +261,7 @@ describe('Endpoint tests', () => {
     const testSigner1 = signersBody1.results.find(r => r.signer_key === testSignerKey1);
     const expectedSignerData1: CycleSigner = {
       signer_key: '0x02e8620935d58ebffa23c260f6917cbd0915ea17d7a46df17e131540237d335504',
+      slot_index: 3,
       weight: 38,
       weight_percentage: 76,
       stacked_amount: '250000000000000',
@@ -296,6 +299,7 @@ describe('Endpoint tests', () => {
     // should return data for the oldest block
     const expected3: CycleSigner = {
       signer_key: '0x02e8620935d58ebffa23c260f6917cbd0915ea17d7a46df17e131540237d335504',
+      slot_index: 3,
       weight: 38,
       weight_percentage: 76,
       stacked_amount: '250000000000000',
@@ -321,6 +325,7 @@ describe('Endpoint tests', () => {
     const body: CycleSignerResponse = responseTest.body;
     const expectedSignerData: CycleSignerResponse = {
       signer_key: '0x02e8620935d58ebffa23c260f6917cbd0915ea17d7a46df17e131540237d335504',
+      slot_index: 3,
       weight: 38,
       weight_percentage: 76,
       stacked_amount: '250000000000000',
@@ -344,6 +349,7 @@ describe('Endpoint tests', () => {
     const miaSigner: CycleSignerResponse = responseTest2.body;
     const expectedMiaSignerData: CycleSigner = {
       signer_key: '0x0399649284ed10a00405f032f8567b5e5463838aaa00af8d6bc9da71dda4e19c9c',
+      slot_index: 9,
       weight: 1,
       weight_percentage: 2,
       stacked_amount: '7700000000000',


### PR DESCRIPTION
Closes https://github.com/hirosystems/signer-metrics-api/issues/40

The sql migration just drops the current table to trigger the existing runtime logic which will detect missing cycle signer sets, fetch them, and insert them (this time with the slot_index data). This is cleaner and less error-prone than an alter-table migration + missing slot_index detection + table updating logic.