### PR TITLE
fix: downgrade breaking change typebox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fastify/type-provider-typebox": "^4.1.0",
         "@hirosystems/api-toolkit": "^1.7.1",
         "@hirosystems/chainhook-client": "^2.3.0",
-        "@sinclair/typebox": "^0.32.35",
+        "@sinclair/typebox": "^0.28.17",
         "@stacks/transactions": "^6.1.0",
         "@types/node": "^20.16.1",
         "date-fns": "^4.1.0",
@@ -2194,9 +2194,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.32.35",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.35.tgz",
-      "integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA==",
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.28.17.tgz",
+      "integrity": "sha512-/twakA+gA4KgkXMiMjWwmV57xmDrm1fp+OaIMz01R3+q7AOSPhnTPZPwxqOzPDslfelxwzZx0Ttp3YdyS1+F4Q==",
       "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@fastify/type-provider-typebox": "^4.1.0",
     "@hirosystems/api-toolkit": "^1.7.1",
     "@hirosystems/chainhook-client": "^2.3.0",
-    "@sinclair/typebox": "^0.32.35",
+    "@sinclair/typebox": "^0.28.17",
     "@stacks/transactions": "^6.1.0",
     "@types/node": "^20.16.1",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
Breaking change in typebox dep is causing a service start crash:
```
TypeCompilerTypeGuardError: Preflight validation check failed to guard for the given schema
```