### PR TITLE
fix: insert last msg id in correct format

### DIFF
--- a/src/pg/ingestion/pg-write-store.ts
+++ b/src/pg/ingestion/pg-write-store.ts
@@ -43,7 +43,8 @@ export class PgWriteStore extends BasePgStoreModule {
   }
 
   async updateLastIngestedRedisMsgId(sql: PgSqlClient, msgId: string): Promise<void> {
-    await sql`UPDATE chain_tip SET last_redis_msg_id = ${msgId}`;
+    const msgSequenceId = msgId.split('-')[0];
+    await sql`UPDATE chain_tip SET last_redis_msg_id = ${msgSequenceId}`;
   }
 
   async applyStackerDbChunk(


### PR DESCRIPTION
The `last_msg_id` expects an integer, but it was trying to insert the msg id format received from redis e.g. `<msgId>-0`.