### PR TITLE
fix: parsing new enums in the BlockResponse(ValidationFailed) chunks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -97,5 +97,27 @@
       ],
       "program": "${workspaceFolder}/testing/csv-to-json.js"
     },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Current js File",
+      "program": "${file}",
+      "cwd": "${fileDirname}",
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Current TS File (ts-node)",
+      "runtimeExecutable": "ts-node",
+      "args": ["--transpile-only", "${file}"],
+      "cwd": "${fileDirname}",
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal",
+      "env": {
+        "TS_NODE_PROJECT": "${workspaceFolder}/tsconfig.json"
+      }
+    }
   ]
 }

--- a/src/event-stream/msg-parsing.ts
+++ b/src/event-stream/msg-parsing.ts
@@ -351,6 +351,7 @@ function parseSignerMessageMetadata(cursor: BufferCursor) {
   return { server_version: cursor.readVecString() };
 }
 
+// https://github.com/stacks-network/stacks-core/blob/e45867c1781a7c45541e765cd42b6a084996fec8/libsigner/src/v0/messages.rs#L934
 const RejectCodeTypePrefix = {
   // The block was rejected due to validation issues
   ValidationFailed: 0,
@@ -367,13 +368,41 @@ const RejectCodeTypePrefix = {
 };
 
 enum ValidateRejectCode {
-  BadBlockHash = 0,
-  BadTransaction = 1,
-  InvalidBlock = 2,
-  ChainstateError = 3,
-  UnknownParent = 4,
-  NonCanonicalTenure = 5,
-  NoSuchTenure = 6,
+  /// The block was rejected due to validation issues
+  ValidationFailed = 0,
+  /// The block was rejected due to connectivity issues with the signer
+  ConnectivityIssues = 1,
+  /// The block was rejected in a prior round
+  RejectedInPriorRound = 2,
+  /// The block was rejected due to no sortition view
+  NoSortitionView = 3,
+  /// The block was rejected due to a mismatch with expected sortition view
+  SortitionViewMismatch = 4,
+  /// The block was rejected due to a testing directive
+  TestingDirective = 5,
+  /// The block attempted to reorg the previous tenure but was not allowed
+  ReorgNotAllowed = 6,
+  /// The bitvec field does not match what is expected
+  InvalidBitvec = 7,
+  /// The miner's pubkey hash does not match the winning pubkey hash
+  PubkeyHashMismatch = 8,
+  /// The miner has been marked as invalid
+  InvalidMiner = 9,
+  /// Miner is last sortition winner, when the current sortition winner is
+  /// still valid
+  NotLatestSortitionWinner = 10,
+  /// The block does not confirm the expected parent block
+  InvalidParentBlock = 11,
+  /// The block contains a block found tenure change, but we've already seen
+  /// a block found
+  DuplicateBlockFound = 12,
+  /// The block attempted a tenure extend but the burn view has not changed
+  /// and not enough time has passed for a time-based tenure extend
+  InvalidTenureExtend = 13,
+  /// Unknown reject code, for forward compatibility
+  Unknown = 254,
+  /// The block was approved, no rejection details needed
+  NotRejected = 255,
 }
 
 // https://github.com/stacks-network/stacks-core/blob/cd702e7dfba71456e4983cf530d5b174e34507dc/libsigner/src/v0/messages.rs#L812

--- a/tests/unit/chunk-parsing.test.ts
+++ b/tests/unit/chunk-parsing.test.ts
@@ -1,0 +1,30 @@
+import { StackerDbChunk } from '../../src/event-stream/core-node-message';
+
+describe('Chunk parsing tests', () => {
+  // Jest has an issue with loading the `@noble/secp256k1` library related to esm limitations in jest
+  test.skip('parse block response with ValidationFailed(PubkeyHashMismatch)', async () => {
+    const { parseStackerDbChunk } = await import('../../src/event-stream/msg-parsing');
+    const payload = `{"contract_id":{"issuer":[22,[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]],"name":"signers-1-1"},"modified_slots":[{"data":"010100000038426c6f636b206973206e6f7420686967686572207468616e20746865206869676865737420626c6f636b20696e206974732074656e7572650008257441ee3785f859ed3a302f2ee19b4ecb3fc3e494c9f982011d6a49a29b36df0000000100f82c5e8637fe8eaf0cee174700841e921c7c16b6163b3804a780f7cbfe35fa8b79a3a2f22878dd66caff6f2ba891b647991147326bbb10de079759edcda3142a00000055737461636b732d7369676e657220332e312e302e302e392e30202872656c656173652f332e312e302e302e393a636262323264362b2c2072656c65617365206275696c642c206c696e7578205b7838365f36345d29030000000a00000000681bbe160008","sig":"01031fe2a0528a2cea71b5cc23e660b5ccddadb730caee4cc0a8388d6df8c5c8fa52d75d243c840c2f34bbc68878b63e7bbb2a6fb0711a843d37f390d366f6d0b4","slot_id":10,"slot_version":176385}]}`;
+    const payloadJson: StackerDbChunk = JSON.parse(payload);
+    const parsed = parseStackerDbChunk(payloadJson);
+    expect(parsed[0]).toMatchObject({
+      contract: 'signers-1-1',
+      pubkey: '025588e24e2bf387fe8cc7bccba1aac7fe599b96724892431e992a40d06e8fe220',
+      sig: '01031fe2a0528a2cea71b5cc23e660b5ccddadb730caee4cc0a8388d6df8c5c8fa52d75d243c840c2f34bbc68878b63e7bbb2a6fb0711a843d37f390d366f6d0b4',
+      messageType: 'BlockResponse',
+      blockResponse: {
+        type: 'rejected',
+        reason: 'Block is not higher than the highest block in its tenure',
+        reasonCode: { rejectCode: 'ValidationFailed', validateRejectCode: 'PubkeyHashMismatch' },
+        signerSignatureHash: '257441ee3785f859ed3a302f2ee19b4ecb3fc3e494c9f982011d6a49a29b36df',
+        chainId: 1,
+        signature:
+          '00f82c5e8637fe8eaf0cee174700841e921c7c16b6163b3804a780f7cbfe35fa8b79a3a2f22878dd66caff6f2ba891b647991147326bbb10de079759edcda3142a',
+        metadata: {
+          server_version:
+            'stacks-signer 3.1.0.0.9.0 (release/3.1.0.0.9:cbb22d6+, release build, linux [x86_64])',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
Fixes an parsing error due to a change in the signer chunk codec:

```
│ Failed to parse message: {"type":"StackerDbChunk","msgId":2895392,"chunk":{"contract_id":{"issuer":[22,[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]],"name":"signers-1-1"},"modified │
│ _slots":[{"data":"010100000038426c6f636b206973206e6f7420686967686572207468616e20746865206869676865737420626c6f636b20696e206974732074656e7572650008257441ee3785f859ed3a302f2ee19b4 │
│ ecb3fc3e494c9f982011d6a49a29b36df0000000100f82c5e8637fe8eaf0cee174700841e921c7c16b6163b3804a780f7cbfe35fa8b79a3a2f22878dd66caff6f2ba891b647991147326bbb10de079759edcda3142a000000 │
│ 55737461636b732d7369676e657220332e312e302e302e392e30202872656c656173652f332e312e302e302e393a636262323264362b2c2072656c65617365206275696c642c206c696e7578205b7838365f36345d2903000 │
│ 0000a00000000681bbe160008","sig":"01031fe2a0528a2cea71b5cc23e660b5ccddadb730caee4cc0a8388d6df8c5c8fa52d75d243c840c2f34bbc68878b63e7bbb2a6fb0711a843d37f390d366f6d0b4","slot_id":1 │
│ 0,"slot_version":176385}]}}                                                                                                                                                       │
│ Error handling message from main thread Error: Invalid enum value: 8, valid values are: BadBlockHash, BadTransaction, InvalidBlock, ChainstateError, UnknownParent, NonCanonicalT │
│ enure, NoSuchTenure, 0, 1, 2, 3, 4, 5, 6                                                                                                                                          │
│     at BufferCursor.readU8Enum (/app/dist/src/event-stream/buffer-cursor.js:19:19)                                                                                                │
│     at parseBlockResponseRejectCode (/app/dist/src/event-stream/msg-parsing.js:273:47)                                                                                            │
│     at parseBlockResponse (/app/dist/src/event-stream/msg-parsing.js:219:32)                                                                                                      │
│     at parseSignerMessage (/app/dist/src/event-stream/msg-parsing.js:71:32)                                                                                                       │
│     at /app/dist/src/event-stream/msg-parsing.js:34:16    
```