### PR TITLE
fix: update SNP lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fastify/swagger": "^8.15.0",
         "@fastify/type-provider-typebox": "^4.1.0",
         "@hirosystems/api-toolkit": "^1.9.0",
-        "@hirosystems/salt-n-pepper-client": "^1.0.4-beta.1",
+        "@hirosystems/salt-n-pepper-client": "^1.1.2",
         "@noble/secp256k1": "^2.2.3",
         "@sinclair/typebox": "^0.28.17",
         "@stacks/transactions": "^7.0.6",
@@ -1406,9 +1406,9 @@
       }
     },
     "node_modules/@hirosystems/salt-n-pepper-client": {
-      "version": "1.0.4-beta.1",
-      "resolved": "https://registry.npmjs.org/@hirosystems/salt-n-pepper-client/-/salt-n-pepper-client-1.0.4-beta.1.tgz",
-      "integrity": "sha512-znfzRNelipy2UbA0knCYo4S2hVipbzCcuKVUGaZTtO2iXIdUyQLj6ZbxMs8lZFwg+Bf0iY/CF5tfNCmPBSJSug==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@hirosystems/salt-n-pepper-client/-/salt-n-pepper-client-1.1.2.tgz",
+      "integrity": "sha512-sExJxLdnkWmBcN08SyfKEmvRbrmlJDUvVsihHW5PbpfirPUBE9e66NaJAAp+GT86WGH+WbmDek5P+Ce6PWDULA==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@hirosystems/api-toolkit": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@fastify/swagger": "^8.15.0",
     "@fastify/type-provider-typebox": "^4.1.0",
     "@hirosystems/api-toolkit": "^1.9.0",
-    "@hirosystems/salt-n-pepper-client": "^1.0.4-beta.1",
+    "@hirosystems/salt-n-pepper-client": "^1.1.2",
     "@noble/secp256k1": "^2.2.3",
     "@sinclair/typebox": "^0.28.17",
     "@stacks/transactions": "^7.0.6",

--- a/src/event-stream/event-stream.ts
+++ b/src/event-stream/event-stream.ts
@@ -43,7 +43,7 @@ export class EventStreamHandler {
     this.eventStream = new StacksEventStream({
       redisUrl: ENV.REDIS_URL,
       redisStreamPrefix: ENV.REDIS_STREAM_KEY_PREFIX,
-      eventStreamType: StacksEventStreamType.all,
+      eventStreamType: StacksEventStreamType.signerEvents,
       lastMessageId: opts.lastMessageId,
       appName,
     });

--- a/src/event-stream/event-stream.ts
+++ b/src/event-stream/event-stream.ts
@@ -43,7 +43,7 @@ export class EventStreamHandler {
     this.eventStream = new StacksEventStream({
       redisUrl: ENV.REDIS_URL,
       redisStreamPrefix: ENV.REDIS_STREAM_KEY_PREFIX,
-      eventStreamType: StacksEventStreamType.signerEvents,
+      eventStreamType: StacksEventStreamType.all,
       lastMessageId: opts.lastMessageId,
       appName,
     });

--- a/tests/db/jest-global-setup.ts
+++ b/tests/db/jest-global-setup.ts
@@ -228,7 +228,7 @@ export default async function setup(): Promise<void> {
     console.log(`Using REDIS_STREAM_KEY_PREFIX: ${process.env.REDIS_STREAM_KEY_PREFIX}`);
     const snpContainer = await startContainer({
       docker,
-      image: 'hirosystems/salt-n-pepper:1.1.1',
+      image: 'hirosystems/salt-n-pepper:1.1.2',
       ports: [{ container: snpObserverPort, host: snpHostPort }],
       env: [
         `OBSERVER_HOST=0.0.0.0`,


### PR DESCRIPTION
Updates to the latest SNP client lib to ensure compatibility with the latest server version.
[Tested and verified](https://grafana.dev.hiro.tools/goto/PkpzHDsHg?orgId=1) against the latest release of SNP as a part of https://github.com/hirosystems/salt-n-pepper/pull/28
https://api.dev.hiro.so/signer-metrics