### PR TITLE
fix: repoint chain tip when tip block is orphaned by a reorg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@sinclair/typebox": "^0.34.48",
         "@stacks/api-toolkit": "^1.13.0",
         "@stacks/codec": "^2.1.0",
-        "@stacks/node-publisher-client": "^2.0.6",
+        "@stacks/node-publisher-client": "^2.2.1",
         "@types/node": "^24.0.0",
         "bignumber.js": "^10.0.2",
         "date-fns": "^4.1.0",
@@ -1130,6 +1130,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1228,64 +1229,76 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@redis/bloom": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.10.0.tgz",
-      "integrity": "sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/client": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
-      "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@redis/json": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.10.0.tgz",
-      "integrity": "sha512-B2G8XlOmTPUuZtD44EMGbtoepQG34RCDXLZbjrtON1Djet0t5Ri7/YPXvL9aomXqP8lLTreaprtyLKF4tmXEEA==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/search": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.10.0.tgz",
-      "integrity": "sha512-3SVcPswoSfp2HnmWbAGUzlbUPn7fOohVu2weUQ0S+EMiQi8jwjL+aN2p6V3TI65eNfVsJ8vyPvqWklm6H6esmg==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz",
-      "integrity": "sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1492,14 +1505,14 @@
       }
     },
     "node_modules/@stacks/node-publisher-client": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@stacks/node-publisher-client/-/node-publisher-client-2.0.6.tgz",
-      "integrity": "sha512-3Z+Qy0/Yzi+9qP/9X8/DVjsh3sHGrZuBAzBxEnSLNADVknBpHKZ/SZzl2GEo/rwZ2xi23HrzCJZYu+381lPNuA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@stacks/node-publisher-client/-/node-publisher-client-2.2.1.tgz",
+      "integrity": "sha512-W1FwbGlSBd0XawoVd6kc5dHFdi4iDC/38wqORH5yIMqbgzBTSZ67YUrDYJPSv6iNFAp8j7Gg4iKCxaxIMpFy3A==",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@stacks/api-toolkit": "^1.12.2",
-        "@stacks/transactions": "^7.3.1",
-        "redis": "^5.10.0"
+        "@stacks/api-toolkit": "^1.13.0",
+        "@stacks/transactions": "^7.4.0",
+        "redis": "^5.12.1"
       }
     },
     "node_modules/@stacks/prettier-config": {
@@ -5141,19 +5154,19 @@
       }
     },
     "node_modules/redis": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
-      "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+      "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "license": "MIT",
       "dependencies": {
-        "@redis/bloom": "5.10.0",
-        "@redis/client": "5.10.0",
-        "@redis/json": "5.10.0",
-        "@redis/search": "5.10.0",
-        "@redis/time-series": "5.10.0"
+        "@redis/bloom": "5.12.1",
+        "@redis/client": "5.12.1",
+        "@redis/json": "5.12.1",
+        "@redis/search": "5.12.1",
+        "@redis/time-series": "5.12.1"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sinclair/typebox": "^0.34.48",
     "@stacks/api-toolkit": "^1.13.0",
     "@stacks/codec": "^2.1.0",
-    "@stacks/node-publisher-client": "^2.0.6",
+    "@stacks/node-publisher-client": "^2.2.1",
     "@types/node": "^24.0.0",
     "bignumber.js": "^10.0.2",
     "date-fns": "^4.1.0",

--- a/src/event-stream/event-stream.ts
+++ b/src/event-stream/event-stream.ts
@@ -1,4 +1,5 @@
 import { PgStore } from '../pg/pg-store.js';
+import { normalizeHexString } from '../helpers.js';
 import { logger as defaultLogger, stopwatch } from '@stacks/api-toolkit';
 import { ENV } from '../env.js';
 import { ParsedNakamotoBlock, ParsedStackerDbChunk } from './msg-parsing.js';
@@ -113,8 +114,26 @@ export class EventStreamHandler {
   async handleNakamotoBlockMsg(block: ParsedNakamotoBlock): Promise<void> {
     const time = stopwatch();
     await this.db.sqlWriteTransaction(async sql => {
-      const { block_height: lastIngestedBlockHeight } = await this.db.getChainTip(sql);
-      if (block.blockHeight <= lastIngestedBlockHeight) {
+      const chainTip = await this.db.getChainTip(sql);
+      if (block.blockHeight <= chainTip.block_height) {
+        const indexBlockHash = normalizeHexString(block.indexBlockHash);
+        if (
+          block.blockHeight === chainTip.block_height &&
+          indexBlockHash !== chainTip.index_block_hash
+        ) {
+          // The previously ingested block at this height was orphaned (e.g. a reorg after a
+          // network stall). Repoint the chain tip at the canonical block, otherwise the stream
+          // handshake resume position can never be resolved and ingestion restarts from scratch
+          // on every reconnect.
+          this.logger.warn(
+            `Chain tip block ${chainTip.block_height} hash ${chainTip.index_block_hash} was orphaned, updating to canonical hash ${indexBlockHash}`
+          );
+          await this.db.ingestion.updateChainTip(sql, {
+            blockHeight: block.blockHeight,
+            indexBlockHash,
+          });
+          return;
+        }
         this.logger.info(`Skipping previously ingested block ${block.blockHeight}`);
         return;
       }

--- a/src/event-stream/event-stream.ts
+++ b/src/event-stream/event-stream.ts
@@ -125,7 +125,7 @@ export class EventStreamHandler {
           // handshake resume position can never be resolved and ingestion restarts from scratch
           // on every reconnect.
           this.logger.warn(
-            `Chain tip block ${chainTip.block_height} hash ${chainTip.index_block_hash} was orphaned, updating to canonical hash ${indexBlockHash}`
+            `Chain tip block ${chainTip.block_height} hash ${chainTip.index_block_hash} was orphaned, updating to canonical hash ${block.indexBlockHash}`
           );
           await this.db.ingestion.updateChainTip(sql, {
             blockHeight: block.blockHeight,

--- a/src/event-stream/event-stream.ts
+++ b/src/event-stream/event-stream.ts
@@ -116,10 +116,9 @@ export class EventStreamHandler {
     await this.db.sqlWriteTransaction(async sql => {
       const chainTip = await this.db.getChainTip(sql);
       if (block.blockHeight <= chainTip.block_height) {
-        const indexBlockHash = normalizeHexString(block.indexBlockHash);
         if (
           block.blockHeight === chainTip.block_height &&
-          indexBlockHash !== chainTip.index_block_hash
+          block.indexBlockHash !== chainTip.index_block_hash
         ) {
           // The previously ingested block at this height was orphaned (e.g. a reorg after a
           // network stall). Repoint the chain tip at the canonical block, otherwise the stream
@@ -130,7 +129,7 @@ export class EventStreamHandler {
           );
           await this.db.ingestion.updateChainTip(sql, {
             blockHeight: block.blockHeight,
-            indexBlockHash,
+            indexBlockHash: block.indexBlockHash,
           });
           return;
         }

--- a/src/event-stream/msg-parsing.ts
+++ b/src/event-stream/msg-parsing.ts
@@ -30,7 +30,7 @@ export interface ParsedNakamotoBlock {
 }
 
 export interface ParsedRewardSet {
-  pox_ustx_threshold: string; // "666720000000000"
+  pox_ustx_threshold?: string; // "666720000000000"
   rewarded_addresses: string[]; // burnchain (btc) addresses
   signers?: {
     signing_key: string; // "03a80704b1eb07b4d526f069d6ac592bb9b8216bcf1734fa40badd8f9867b4c79e",

--- a/tests/db/ingestion.test.ts
+++ b/tests/db/ingestion.test.ts
@@ -61,10 +61,12 @@ describe('End-to-end ingestion tests', () => {
     assert.ok(signerData);
     assert.equal(signerData.length, 3);
 
-    assert.equal(signerData[0].signer_key,
+    assert.equal(
+      signerData[0].signer_key,
       '0x028efa20fa5706567008ebaf48f7ae891342eeb944d96392f719c505c89f84ed8d'
     );
-    assert.equal(signerData[0].last_metadata_server_version,
+    assert.equal(
+      signerData[0].last_metadata_server_version,
       'stacks-signer 0.0.1 (:dd1ebe64603f54dae48558a5d82d9bd885e97a01, debug build, linux [aarch64])'
     );
     assert.equal(signerData[0].stacked_amount, '4125240000000000');
@@ -74,10 +76,12 @@ describe('End-to-end ingestion tests', () => {
     assert.equal(signerData[0].weight, 4);
     assert.equal(signerData[0].weight_percentage, 50);
 
-    assert.equal(signerData[1].signer_key,
+    assert.equal(
+      signerData[1].signer_key,
       '0x023f19d77c842b675bd8c858e9ac8b0ca2efa566f17accf8ef9ceb5a992dc67836'
     );
-    assert.equal(signerData[1].last_metadata_server_version,
+    assert.equal(
+      signerData[1].last_metadata_server_version,
       'stacks-signer 0.0.1 (:dd1ebe64603f54dae48558a5d82d9bd885e97a01, debug build, linux [aarch64])'
     );
     assert.equal(signerData[1].stacked_amount, '2750160000000000');
@@ -87,10 +91,12 @@ describe('End-to-end ingestion tests', () => {
     assert.equal(signerData[1].weight, 3);
     assert.equal(signerData[1].weight_percentage, 37.5);
 
-    assert.equal(signerData[2].signer_key,
+    assert.equal(
+      signerData[2].signer_key,
       '0x029fb154a570a1645af3dd43c3c668a979b59d21a46dd717fd799b13be3b2a0dc7'
     );
-    assert.equal(signerData[2].last_metadata_server_version,
+    assert.equal(
+      signerData[2].last_metadata_server_version,
       'stacks-signer 0.0.1 (:dd1ebe64603f54dae48558a5d82d9bd885e97a01, debug build, linux [aarch64])'
     );
     assert.equal(signerData[2].stacked_amount, '1375080000000000');
@@ -113,9 +119,50 @@ describe('End-to-end ingestion tests', () => {
     assert.equal(signerData?.stacked_amount_rank, 1);
     assert.equal(signerData?.weight, 4);
     assert.equal(signerData?.weight_percentage, 50);
-    assert.equal(signerData?.signer_key,
+    assert.equal(
+      signerData?.signer_key,
       '0x028efa20fa5706567008ebaf48f7ae891342eeb944d96392f719c505c89f84ed8d'
     );
+  });
+
+  test('chain tip is repointed when its block is orphaned by a reorg', async () => {
+    const eventStreamHandler = new EventStreamHandler({ db });
+    try {
+      // Get the last /new_block message from the sample events dump (the current chain tip)
+      const payloadDumpFile = './tests/db/dumps/stackerdb-sample-events.tsv.gz';
+      const lines = zlib.gunzipSync(fs.readFileSync(payloadDumpFile)).toString('utf8').split('\n');
+      const lastNewBlockLine = lines.filter(line => line.split('\t')[2] === '/new_block').at(-1);
+      assert.ok(lastNewBlockLine);
+      const [id, timestamp, path, payload] = lastNewBlockLine.split('\t');
+      const blockMsg = JSON.parse(payload) as { block_height: number; index_block_hash: string };
+      assert.equal(blockMsg.block_height, sampleEventsBlockHeight);
+
+      const chainTipBefore = await db.getChainTip(db.sql);
+      assert.equal(chainTipBefore.index_block_hash, blockMsg.index_block_hash);
+
+      // Replaying the same canonical block is a no-op
+      await eventStreamHandler.handleMsg(id, timestamp, {
+        path,
+        payload: blockMsg,
+      } as Message);
+      let chainTip = await db.getChainTip(db.sql);
+      assert.equal(chainTip.block_height, sampleEventsBlockHeight);
+      assert.equal(chainTip.index_block_hash, chainTipBefore.index_block_hash);
+
+      // A replayed block at the same height with a different index_block_hash means the
+      // previously ingested tip block was orphaned - the chain tip hash must be repointed
+      const canonicalHash = '0x' + 'ab'.repeat(32);
+      blockMsg.index_block_hash = canonicalHash;
+      await eventStreamHandler.handleMsg(id, timestamp, {
+        path,
+        payload: blockMsg,
+      } as Message);
+      chainTip = await db.getChainTip(db.sql);
+      assert.equal(chainTip.block_height, sampleEventsBlockHeight);
+      assert.equal(chainTip.index_block_hash, canonicalHash);
+    } finally {
+      await eventStreamHandler.threadedParser.close();
+    }
   });
 
   test('validate current cycle signer weight percentages', async () => {


### PR DESCRIPTION
## Problem

During a network stall recovery, the block at the API's chain tip can be orphaned by a reorg. The event stream handshake resumes by resolving `chain_tip.index_block_hash` against the SNP server's message log, and an orphaned hash can never be resolved — the server falls back to replaying from the beginning of its history. Since `handleNakamotoBlockMsg` skipped every replayed block with `height <= chain tip height`, the orphaned hash was never corrected, so each reconnect (e.g. after the server prunes a slow consumer mid-backfill) restarted the full replay from scratch: ingestion loops forever without making progress, endlessly logging `Skipped inserting duplicate block proposal ...`.

## Fix

When a replayed `new_block` arrives at the same height as the chain tip but with a different `index_block_hash`, update `chain_tip.index_block_hash` to the canonical hash instead of skipping the block. The canonical chain always contains exactly one block at the tip height, so replaying it self-heals the resume position; the next handshake then resolves to the correct stream position instead of sequence 0.

Blocks strictly below the tip height are still skipped as before.

## Testing

Added a regression test to the ingestion suite that replays the sample dump's tip block twice: unchanged (asserts no-op) and with a mutated `index_block_hash` (asserts the tip hash is repointed while the height is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)